### PR TITLE
feat(tracker): rename library to yawa-tracker as enforced by npm

### DIFF
--- a/.github/workflows/tracker-release.yml
+++ b/.github/workflows/tracker-release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: Build
-        run: bun run --filter yawa build
+        run: bun run --filter yawa-tracker build
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ What are my top pages this week?
 Install the tracker in your website or frontend app:
 
 ```bash
-npm install yawa
+npm install yawa-tracker
 ```
 
 ### Setup
 
 ```ts
-import { initYawa } from "yawa";
+import { initYawa } from "yawa-tracker";
 
 const cleanup = initYawa({
   serverUrl: "https://your-yawa-server.com",
@@ -133,7 +133,7 @@ This automatically tracks page views on load and navigation (SPA-friendly via `h
 To track a custom event, call `trackEvent` with a name and optional metadata:
 
 ```ts
-import { trackEvent } from "yawa";
+import { trackEvent } from "yawa-tracker";
 
 trackEvent({ name: "signup", metadata: { plan: "pro" } });
 ```
@@ -145,7 +145,7 @@ Keys and values must be strings, with a maximum of 10 keys and 200 characters pe
 Core Web Vitals (CLS, FCP, INP, LCP, TTFB) can also be collected by enabling the option when initializing the tracker:
 
 ```ts
-import { initYawa } from "yawa";
+import { initYawa } from "yawa-tracker";
 
 const cleanup = initYawa({
   serverUrl: "https://your-yawa-server.com",

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
       },
     },
     "packages/tracker": {
-      "name": "yawa",
+      "name": "yawa-tracker",
       "version": "0.0.1",
       "dependencies": {
         "web-vitals": "^5.3.0",
@@ -377,8 +377,6 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "yawa": ["yawa@workspace:packages/tracker"],
-
     "yawa-app": ["yawa-app@workspace:packages/app"],
 
     "yawa-cli": ["yawa-cli@workspace:packages/cli"],
@@ -388,6 +386,8 @@
     "yawa-db": ["yawa-db@workspace:packages/db"],
 
     "yawa-schema": ["yawa-schema@workspace:packages/schema"],
+
+    "yawa-tracker": ["yawa-tracker@workspace:packages/tracker"],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 

--- a/packages/tracker/package.json
+++ b/packages/tracker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yawa",
+  "name": "yawa-tracker",
   "version": "0.0.1",
   "description": "Tracking library for yet another web analytics.",
   "bugs": {


### PR DESCRIPTION
WTF

```
❯ npm publish --access public
...
npm error code E403
npm error 403 403 Forbidden - PUT https://registry.npmjs.org/yawa - Package name too similar to existing packages yalc,yaml,yazl,yarn,ava; try renaming your package to '@peterpeterparker/yawa' and publishing with 'npm publish --access=public' instead
npm error 403 In most cases, you or one of your dependencies are requesting a package version that is forbidden by your security policy, or on a server you do not have access to.
npm error A complete log of this run can be found in: /Users/daviddalbusco/.npm/_logs/2026-06-17T15_17_40_114Z-debug-0.log
```
