### PR TITLE
feat(tracker,db): support for web-vitals type soft-navigation

### DIFF
--- a/packages/db/migrations/0004_web_vitals_soft_navigation.sql
+++ b/packages/db/migrations/0004_web_vitals_soft_navigation.sql
@@ -1,0 +1,5 @@
+-- Extend the navigation type with the "soft-navigation" type introduced in web-vitals@v6.
+-- Note: DuckDB does not support altering an enum type, e.g.
+-- ALTER TYPE yawa_analytics.navigation_type ADD VALUE 'soft_navigation';
+-- Therefore, the entire type needs to be recreated.
+CREATE OR REPLACE TYPE yawa_analytics.navigation_type AS ENUM ('navigate', 'reload', 'back_forward', 'back_forward_cache', 'prerender', 'restore', 'soft_navigation');

--- a/packages/db/tests/migrate.test.ts
+++ b/packages/db/tests/migrate.test.ts
@@ -52,7 +52,7 @@ describe("migrate", () => {
       return;
     }
 
-    expect(applied.result.length).toBe(3);
+    expect(applied.result.length).toBe(4);
 
     expect(applied.result[0]?.filename).toBe("0001_admin.sql");
     expect(applied.result[0]?.id).toBeDefined();
@@ -65,5 +65,46 @@ describe("migrate", () => {
     expect(applied.result[2]?.filename).toBe("0003_linked_sites.sql");
     expect(applied.result[2]?.id).toBeDefined();
     expect(applied.result[2]?.executed_at).toBeDefined();
+
+    expect(applied.result[3]?.filename).toBe("0004_web_vitals_soft_navigation.sql");
+    expect(applied.result[3]?.id).toBeDefined();
+    expect(applied.result[3]?.executed_at).toBeDefined();
+  });
+
+  describe("0004_web_vitals_soft_navigation", () => {
+    test("adds soft_navigation while preserving existing navigation types", async () => {
+      await migrate({ instance });
+
+      const connectionResult = await instance.connect();
+
+      if (connectionResult.status === "error") {
+        expect(true).toBeFalsy();
+        return;
+      }
+
+      const result = await connectionResult.result.query({
+        sql: `
+      SELECT enum_range(NULL::yawa_analytics.navigation_type) AS values
+    `,
+        schema: z.object({
+          values: z.array(z.string()),
+        }),
+      });
+
+      if (result.status === "error") {
+        expect(true).toBeFalsy();
+        return;
+      }
+
+      expect(result.result[0]?.values).toEqual([
+        "navigate",
+        "reload",
+        "back_forward",
+        "back_forward_cache",
+        "prerender",
+        "restore",
+        "soft_navigation",
+      ]);
+    });
   });
 });

--- a/packages/tracker/src/services/performance.service.ts
+++ b/packages/tracker/src/services/performance.service.ts
@@ -92,6 +92,8 @@ export class PerformanceService {
           return "back_forward_cache";
         case "prerender":
           return "prerender";
+        case "soft-navigation":
+          return "soft_navigation";
         default:
           return undefined;
       }

--- a/packages/tracker/src/types/api.ts
+++ b/packages/tracker/src/types/api.ts
@@ -42,7 +42,8 @@ export type NavigationType =
   | "back_forward"
   | "back_forward_cache"
   | "prerender"
-  | "restore";
+  | "restore"
+  | "soft_navigation";
 
 export interface SetPerformanceMetricRequest extends SetRequest {
   href: string;

--- a/packages/tracker/tests/services/performance.service.test.ts
+++ b/packages/tracker/tests/services/performance.service.test.ts
@@ -57,6 +57,7 @@ describe("PerformanceService.mapPerformanceMetric", () => {
       ["back-forward", "back_forward"],
       ["back-forward-cache", "back_forward_cache"],
       ["prerender", "prerender"],
+      ["soft-navigation", "soft_navigation"],
     ] as const)("maps %s to %s", async (input, expected) => {
       let result: unknown;
 


### PR DESCRIPTION
Type "soft-navigation" was introduced in web-vitals [release v6](https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v600-2026-07-21)