### PR TITLE
chore(app,cli,tracker): release version (clean semver)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/app": {
       "name": "yawa-app",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "dependencies": {
         "@hono/mcp": "^0.3.2",
         "@hono/zod-validator": "^0.9.1",
@@ -35,7 +35,7 @@
     },
     "packages/cli": {
       "name": "yawa-cli",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "dependencies": {
         "yawa-common": "workspace:*",
         "yawa-schema": "workspace:*",
@@ -77,7 +77,7 @@
     },
     "packages/tracker": {
       "name": "yawa-tracker",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "web-vitals": "^6.2.1",
       },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yawa-app",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "private": true,
   "type": "module",
   "module": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yawa-cli",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "private": true,
   "type": "module",
   "module": "src/index.ts",

--- a/packages/tracker/package.json
+++ b/packages/tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yawa-tracker",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Tracking library for yet another web analytics.",
   "bugs": {
     "url": "https://github.com/peterpeterparker/yawa"


### PR DESCRIPTION
Release [app/v0.0.8](https://github.com/peterpeterparker/yawa/releases#release-app/v0.0.8) is ok but, I'm stupid: I bumped the app/cli versions in a branch (🤦‍♂️) instead of main. This is also why the tracker wasn't release ([action](https://github.com/peterpeterparker/yawa/actions/runs/33407652022))

So this PRs bumps the version cleanly.